### PR TITLE
fix t.Fatal calls with formatting directives

### DIFF
--- a/btree_test.go
+++ b/btree_test.go
@@ -704,7 +704,7 @@ func TestCursor(t *testing.T) {
 	x := strings.Join(a, ",")
 	e := "0,2,4,6,8,10,12,14,16,18"
 	if x != e {
-		t.Fatal("expected '%v', got '%v'", e, x)
+		t.Fatalf("expected '%v', got '%v'", e, x)
 	}
 
 	c = tr.Cursor()
@@ -715,7 +715,7 @@ func TestCursor(t *testing.T) {
 	x = strings.Join(a, ",")
 	e = "18,16,14,12,10,8,6,4,2,0"
 	if x != e {
-		t.Fatal("expected '%v', got '%v'", e, x)
+		t.Fatalf("expected '%v', got '%v'", e, x)
 	}
 
 	for i := 0; i < 20; i++ {


### PR DESCRIPTION
In Go 1.12, running `go test` exits with the following errors:

```
./btree_test.go:707:3: Fatal call has possible formatting directive %v
./btree_test.go:718:3: Fatal call has possible formatting directive %v
```

This PR fixes those issues. 