### PR TITLE
Added context getter and setter

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -822,6 +822,16 @@ func (t *BTree) Len() int {
 	return t.length
 }
 
+// Context returns the context of the tree.
+func (t *BTree) Context() interface{} {
+	return t.ctx
+}
+
+// SetContext will replace the context of the tree.
+func (t *BTree) SetContext(ctx interface{}) {
+	t.ctx = ctx
+}
+
 // Int implements the Item interface for integers.
 type Int int
 

--- a/btree_test.go
+++ b/btree_test.go
@@ -343,6 +343,18 @@ func TestDescendGreaterThan(t *testing.T) {
 	}
 }
 
+func TestContext(t *testing.T) {
+	tr := New(*btreeDegree, nil)
+	if tr.Context() != nil {
+		t.Fatalf("context:\n got: %v\nwant: %v", tr.Context(), nil)
+	}
+	ctx := "foo"
+	tr.SetContext(ctx)
+	if tr.Context() != ctx {
+		t.Fatalf("context:\n got: %v\nwant: %v", tr.Context(), ctx)
+	}
+}
+
 const benchmarkTreeSize = 10000
 
 func BenchmarkInsert(b *testing.B) {

--- a/btree_test.go
+++ b/btree_test.go
@@ -704,7 +704,7 @@ func TestCursor(t *testing.T) {
 	x := strings.Join(a, ",")
 	e := "0,2,4,6,8,10,12,14,16,18"
 	if x != e {
-		t.Fatal("expected '%v', got '%v'", e, x)
+		t.Fatalf("expected '%v', got '%v'", e, x)
 	}
 
 	c = tr.Cursor()
@@ -715,7 +715,7 @@ func TestCursor(t *testing.T) {
 	x = strings.Join(a, ",")
 	e = "18,16,14,12,10,8,6,4,2,0"
 	if x != e {
-		t.Fatal("expected '%v', got '%v'", e, x)
+		t.Fatalf("expected '%v', got '%v'", e, x)
 	}
 
 	for i := 0; i < 20; i++ {


### PR DESCRIPTION
Allows changing the context of a tree.

In my scenario the context is the parent data structure that holds the tree. If I clone that data structure and the tree using `Clone` I need to update the context to point to the new data structure to prevent leaking memory.

Might be useful to others as well.