### PR TITLE
Seek fails to find greater-or-equal key

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -1027,12 +1027,8 @@ func (iter *GenericIter[T]) Seek(key T) bool {
 			return true
 		}
 		if n.leaf() {
-			if i == len(n.items) {
-				iter.stack = iter.stack[:0]
-				return false
-			}
-			iter.item = n.items[i]
-			return true
+			iter.stack[len(iter.stack)-1].i--
+			return iter.Next()
 		}
 		n = (*n.children)[i]
 	}

--- a/generic_test.go
+++ b/generic_test.go
@@ -1331,3 +1331,19 @@ func TestGenericIterSeek(t *testing.T) {
 		assert(vals[0] == 502 && vals[1] == 500)
 	}
 }
+
+func TestGenericIterSeekPrefix(t *testing.T) {
+	tr := NewGeneric(func(a, b int) bool {
+		return a < b
+	})
+	count := 10_000
+	for i := 0; i < count; i++ {
+		tr.Set(i * 2)
+	}
+	for i := 0; i < count; i++ {
+		iter := tr.Iter()
+		ret := iter.Seek(i*2 - 1)
+		assert(ret == true)
+		iter.Release()
+	}
+}


### PR DESCRIPTION
It looks like `GenericIter[T].Seek()` is unable to find a greater-or-equal key in some cases. Here is a simple test case that reproduces the issue.