### PR TITLE
Put Deprecated comments to new paragraph

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -20,6 +20,7 @@ func New(less func(a, b any) bool) *BTree {
 //
 // This is useful for when you do not need the BTree to manage the locking,
 // but would rather do it yourself.
+//
 // Deprecated: use NewOptions
 func NewNonConcurrent(less func(a, b any) bool) *BTree {
 	if less == nil {

--- a/btreeg.go
+++ b/btreeg.go
@@ -1306,18 +1306,21 @@ func (tr *BTreeG[T]) Clear() {
 }
 
 // Generic BTree
+//
 // Deprecated: use BTreeG
 type Generic[T any] struct {
 	*BTreeG[T]
 }
 
 // NewGeneric returns a generic BTree
+//
 // Deprecated: use NewBTreeG
 func NewGeneric[T any](less func(a, b T) bool) *Generic[T] {
 	return &Generic[T]{NewBTreeGOptions(less, Options{})}
 }
 
 // NewGenericOptions returns a generic BTree
+//
 // Deprecated: use NewBTreeGOptions
 func NewGenericOptions[T any](less func(a, b T) bool, opts Options) *Generic[T] {
 	return &Generic[T]{NewBTreeGOptions(less, opts)}


### PR DESCRIPTION
> To signal that an identifier should not be used, add a paragraph to its doc comment that begins with “Deprecated:” followed by some information about the deprecation.
https://go.dev/blog/godoc

Without the new paragraph linters (e.g. statickcheck) and IDEs (e.g. vscode) doesn't recognise the deprecation.