### PR TITLE
skip allocating mutex if it isn't required

### DIFF
--- a/btreeg.go
+++ b/btreeg.go
@@ -54,8 +54,10 @@ func NewBTreeG[T any](less func(a, b T) bool) *BTreeG[T] {
 func NewBTreeGOptions[T any](less func(a, b T) bool, opts Options) *BTreeG[T] {
 	tr := new(BTreeG[T])
 	tr.isoid = newIsoID()
-	tr.mu = new(sync.RWMutex)
 	tr.locks = !opts.NoLocks
+	if tr.locks {
+		tr.mu = new(sync.RWMutex)
+	}
 	tr.less = less
 	tr.init(opts.Degree)
 	return tr
@@ -1066,13 +1068,15 @@ func (tr *BTreeG[T]) Copy() *BTreeG[T] {
 }
 
 func (tr *BTreeG[T]) IsoCopy() *BTreeG[T] {
+	var mu *sync.RWMutex
 	if tr.lock(true) {
+		mu = new(sync.RWMutex)
 		defer tr.unlock(true)
 	}
 	tr.isoid = newIsoID()
 	tr2 := new(BTreeG[T])
 	*tr2 = *tr
-	tr2.mu = new(sync.RWMutex)
+	tr2.mu = mu
 	tr2.isoid = newIsoID()
 	return tr2
 }


### PR DESCRIPTION
I noticed an optimization opportunity when `NoLocks` is set to skip allocating a `sync.RWMutex` inside `Copy` where it isn't necessary.

I made the change in the constructor too just for consistency, but I'm happy to remove that since it is not as important as the optimization in `Copy` for trees which are copied frequently.

Tests passed for me locally, but I didn't verifying if the tests that exist are sufficient for finding regressions for a change like this.