### PR TITLE
add iter pool to reduce allocations

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,25 @@
+// Copyright 2020 Joshua J Baker. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+package btree
+
+import (
+	"testing"
+)
+
+func BenchmarkIterAndSeek(b *testing.B) {
+	tree := NewBTreeGOptions(func(a, b int) bool {
+		return a < b
+	}, Options{
+		Degree: 4,
+	})
+	for i := 0; i < 10<<20; i++ {
+		tree.Set(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		iter := tree.Iter()
+		iter.Seek(1)
+		iter.Release()
+	}
+}

--- a/btree.go
+++ b/btree.go
@@ -338,7 +338,7 @@ func (tr *BTree) Clear() {
 
 // Iter is an iterator for
 type Iter struct {
-	base IterG[any]
+	base *IterG[any]
 }
 
 // Iter returns a read-only iterator.


### PR DESCRIPTION
    add iter pool to reduce allocations
    
    before:
    
    ```
    goos: linux
    goarch: amd64
    pkg: github.com/tidwall/btree
    cpu: AMD Ryzen 9 7900 12-Core Processor
    BenchmarkSeek-24        14578284                77.03 ns/op          112 B/op          1 allocs/op
    BenchmarkSeek-24        17114732                77.62 ns/op          112 B/op          1 allocs/op
    BenchmarkSeek-24        14355789                77.14 ns/op          112 B/op          1 allocs/op
    BenchmarkSeek-24        13331631                77.73 ns/op          112 B/op          1 allocs/op
    BenchmarkSeek-24        16061071                74.89 ns/op          112 B/op          1 allocs/op
    PASS
    ok      github.com/tidwall/btree        6.208s
    ```
    
    after:
    
    ```
    goos: linux
    goarch: amd64
    pkg: github.com/tidwall/btree
    cpu: AMD Ryzen 9 7900 12-Core Processor
    BenchmarkIterAndSeek-24         59014582                17.01 ns/op            0 B/op          0 allocs/op
    BenchmarkIterAndSeek-24         80387774                15.13 ns/op            0 B/op          0 allocs/op
    BenchmarkIterAndSeek-24         78966735                15.88 ns/op            0 B/op          0 allocs/op
    BenchmarkIterAndSeek-24         77028037                15.63 ns/op            0 B/op          0 allocs/op
    BenchmarkIterAndSeek-24         71239053                16.44 ns/op            0 B/op          0 allocs/op
    PASS
    ok      github.com/tidwall/btree        5.939s
    ```
