### PR TITLE
add ReadOnly mode and change IsoCopy behavior

### DIFF
--- a/btreeg.go
+++ b/btreeg.go
@@ -13,6 +13,7 @@ type BTreeG[T any] struct {
 	locks        bool
 	copyItems    bool
 	isoCopyItems bool
+	readOnly     bool
 	less         func(a, b T) bool
 	empty        T
 	max          int
@@ -44,6 +45,8 @@ type Options struct {
 	// NoLocks will disable locking. Otherwide a sync.RWMutex is used to
 	// ensure all operations are safe across multiple goroutines.
 	NoLocks bool
+	// ReadOnly marks the tree as read-only, any modifications will trigger panic.
+	ReadOnly bool
 }
 
 // New returns a new BTree
@@ -58,7 +61,15 @@ func NewBTreeGOptions[T any](less func(a, b T) bool, opts Options) *BTreeG[T] {
 	tr.locks = !opts.NoLocks
 	tr.less = less
 	tr.init(opts.Degree)
+	if opts.ReadOnly {
+		tr.Freeze()
+	}
 	return tr
+}
+
+// Freeze marks the tree as read-only.
+func (tr *BTreeG[T]) Freeze() {
+	tr.readOnly = true
 }
 
 func (tr *BTreeG[T]) init(degree int) {
@@ -192,6 +203,9 @@ path_match:
 
 // SetHint sets or replace a value for a key using a path hint
 func (tr *BTreeG[T]) SetHint(item T, hint *PathHint) (prev T, replaced bool) {
+	if tr.readOnly {
+		panic("read-only tree")
+	}
 	if tr.locks {
 		tr.mu.Lock()
 		prev, replaced = tr.setHint(item, hint)
@@ -441,6 +455,9 @@ func (tr *BTreeG[T]) Delete(key T) (T, bool) {
 // deleted value.
 // Returns false if there was no value by that key found.
 func (tr *BTreeG[T]) DeleteHint(key T, hint *PathHint) (T, bool) {
+	if tr.readOnly {
+		panic("read-only tree")
+	}
 	if tr.lock(true) {
 		defer tr.unlock(true)
 	}
@@ -761,6 +778,9 @@ func (tr *BTreeG[T]) nodeDescend(cn **node[T], pivot T, hint *PathHint,
 
 // Load is for bulk loading pre-sorted items
 func (tr *BTreeG[T]) Load(item T) (T, bool) {
+	if tr.readOnly {
+		panic("read-only tree")
+	}
 	if tr.lock(true) {
 		defer tr.unlock(true)
 	}
@@ -849,6 +869,9 @@ func (tr *BTreeG[T]) maxMut(mut bool) (T, bool) {
 // PopMin removes the minimum item in tree and returns it.
 // Returns nil if the tree has no items.
 func (tr *BTreeG[T]) PopMin() (T, bool) {
+	if tr.readOnly {
+		panic("read-only tree")
+	}
 	if tr.lock(true) {
 		defer tr.unlock(true)
 	}
@@ -890,6 +913,9 @@ func (tr *BTreeG[T]) PopMin() (T, bool) {
 // PopMax removes the maximum item in tree and returns it.
 // Returns nil if the tree has no items.
 func (tr *BTreeG[T]) PopMax() (T, bool) {
+	if tr.readOnly {
+		panic("read-only tree")
+	}
 	if tr.lock(true) {
 		defer tr.unlock(true)
 	}
@@ -963,6 +989,9 @@ func (tr *BTreeG[T]) getAt(index int, mut bool) (T, bool) {
 // DeleteAt deletes the item at index.
 // Return nil if the tree is empty or the index is out of bounds.
 func (tr *BTreeG[T]) DeleteAt(index int) (T, bool) {
+	if tr.readOnly {
+		panic("read-only tree")
+	}
 	if tr.lock(true) {
 		defer tr.unlock(true)
 	}
@@ -1090,14 +1119,17 @@ func (tr *BTreeG[T]) Copy() *BTreeG[T] {
 }
 
 func (tr *BTreeG[T]) IsoCopy() *BTreeG[T] {
-	if tr.lock(true) {
-		defer tr.unlock(true)
+	if tr.lock(!tr.readOnly) {
+		defer tr.unlock(!tr.readOnly)
 	}
-	tr.isoid = newIsoID()
+	if !tr.readOnly {
+		tr.isoid = newIsoID()
+	}
 	tr2 := new(BTreeG[T])
 	*tr2 = *tr
 	tr2.mu = new(sync.RWMutex)
 	tr2.isoid = newIsoID()
+	tr2.readOnly = false
 	return tr2
 }
 
@@ -1393,6 +1425,9 @@ func (tr *BTreeG[T]) nodeItems(cn **node[T], items []T, mut bool) []T {
 
 // Clear will delete all items.
 func (tr *BTreeG[T]) Clear() {
+	if tr.readOnly {
+		panic("read-only tree")
+	}
 	if tr.lock(true) {
 		defer tr.unlock(true)
 	}


### PR DESCRIPTION
I'm experimenting with the optimistic concurrency control pattern using the `IsoCopy` feature, it should be useful in read-heavy scenarios.

```
type BTree[T any] struct {
	atomic.Pointer[btree.BTreeG[T]]
}

func NewBTree[T any](less func(a, b T) bool) *BTree[T] {
	tree := btree.NewBTreeGOptions[T](less, btree.Options{
		NoLocks:  true,
		ReadOnly: true,
	})
	t := &BTree[T]{}
	t.Store(tree)
	return t
}

func (bt *BTree[T]) Get(item T) (result T, ok bool) {
	return bt.Load().Get(item)
}

func (bt *BTree[T]) Set(item T) (prev T, ok bool) {
	for {
		t := bt.Load()
		c := t.Copy()
		prev, ok = c.Set(item)
		c.Freeze()
		if bt.CompareAndSwap(t, c) {
			return
		}
		runtime.Gosched()
	}
}
```