### PR TITLE
fix #47. fix #48.

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -116,7 +116,7 @@ func (tr *BTree) DeleteHint(key any, hint *PathHint) (prev any) {
 	if key == nil {
 		return nil
 	}
-	v, ok := tr.base.DeleteHint(key, nil)
+	v, ok := tr.base.DeleteHint(key, hint)
 	if !ok {
 		return nil
 	}

--- a/btreeg.go
+++ b/btreeg.go
@@ -94,7 +94,7 @@ func (n *node[T]) leaf() bool {
 func (tr *BTreeG[T]) bsearch(n *node[T], key T) (index int, found bool) {
 	low, high := 0, len(n.items)
 	for low < high {
-		h := (low + high) / 2
+		h := int(uint(low+high) >> 1) // avoid overflow when computing h
 		if !tr.less(key, n.items[h]) {
 			low = h + 1
 		} else {


### PR DESCRIPTION
BTree.DeleteHint() actually uses the hint. 

BTreeG[T].bsearch() avoids overflow. Prevents incorrect results on very large trees.
