### PR TITLE
optimize iterator Release/Init to avoid heap escape

### DIFF
--- a/btreeg.go
+++ b/btreeg.go
@@ -1698,6 +1698,8 @@ func (iter *IterG[T]) Release() {
 	iter.seeked = false
 	iter.atstart = false
 	iter.atend = false
+	var empty T
+	iter.item = empty
 }
 
 // Init is used to initialize an existing iterator with a new tree. Release must've
@@ -1710,7 +1712,17 @@ func (iter *IterG[T]) Init(tr *BTreeG[T], mut bool) {
 	iter.seeked = false
 	iter.atstart = false
 	iter.atend = false
-	iter.locked = tr.lock(iter.mut)
+	iter.locked = false
+	if tr != nil {
+		iter.locked = tr.lock(iter.mut)
+	}
+	var empty T
+	iter.item = empty
+	if iter.stack == nil {
+		iter.stack = iter.stack0[:0]
+	} else {
+		iter.stack = iter.stack[:0]
+	}
 }
 
 // Next moves iterator to the next item in iterator.

--- a/btreeg_test.go
+++ b/btreeg_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"reflect"
 	"runtime"
 	"sort"
 	"strconv"
@@ -1895,6 +1896,28 @@ func useIteratorPointer(iter *IterG[largeItem]) {
 	assert(iter.Item().a == 0)
 }
 
+func assertIteratorCleared[T any](t *testing.T, iter IterG[T]) {
+	t.Helper()
+	v := reflect.ValueOf(iter)
+	vt := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		name := vt.Field(i).Name
+		switch name {
+		case "stack", "stack0":
+			continue
+		}
+		if !v.Field(i).IsZero() {
+			t.Fatalf("iterator field %s was not reset", name)
+		}
+	}
+	if len(iter.stack) != 0 {
+		t.Fatal("iterator stack length not reset")
+	}
+	if cap(iter.stack) == 0 {
+		t.Fatal("iterator stack capacity should be preserved for reuse")
+	}
+}
+
 // This benchmark proves that there exist cases where the iterator creation can
 // cause an allocation
 //
@@ -1993,13 +2016,7 @@ func TestGenericIteratorRelease(t *testing.T) {
 		panic("!")
 	}
 	iter.Release()
-	if iter.tr != nil || iter.locked || iter.mut || iter.seeked ||
-		iter.atstart || iter.atend || len(iter.stack) != 0 {
-		panic("!")
-	}
-	if cap(iter.stack) == 0 {
-		panic("!")
-	}
+	assertIteratorCleared(t, iter)
 }
 
 func TestGenericIteratorInit(t *testing.T) {
@@ -2029,7 +2046,8 @@ func TestGenericIteratorInit(t *testing.T) {
 	if count != 50 {
 		panic("!")
 	}
-	iter.Release()
+	iter.Init(nil, false)
+	assertIteratorCleared(t, iter)
 }
 
 func TestGenericIteratorReuse(t *testing.T) {


### PR DESCRIPTION
* prevent heap escape during iterator reuse by replacing `*iter = IterG[T]{}` with manual field clearing
* improve performance in high-frequency iterator reuse scenarios

```
benchstat /private/tmp/bf.txt /private/tmp/af.txt 
seed: 1
goos: darwin
goarch: arm64
pkg: github.com/tidwall/btree
cpu: Apple M4 Max
                                  │ /private/tmp/bf.txt │         /private/tmp/af.txt         │
                                  │       sec/op        │    sec/op     vs base               │
IteratorCreationAlloc/no_reuse-16           39.31n ± 1%   37.68n ± 12%        ~ (p=0.132 n=6)
IteratorCreationAlloc/reuse-16              15.61n ± 1%   12.98n ±  0%  -16.88% (p=0.002 n=6)
IteratorRelease-16                         11.575n ± 1%   9.409n ±  1%  -18.71% (p=0.002 n=6)
IteratorReuse/Recreate-16                   2.160µ ± 1%   2.118µ ±  1%   -1.99% (p=0.002 n=6)
IteratorReuse/Reuse-16                      2.169µ ± 1%   2.142µ ±  1%   -1.22% (p=0.019 n=6)
geomean                                     127.2n        115.8n         -8.91%
```